### PR TITLE
Unlock traceJaegerApplicationName and traceZipkinApplicationName

### DIFF
--- a/wavefront/README.md
+++ b/wavefront/README.md
@@ -84,6 +84,8 @@ The following tables lists the configurable parameters of the Wavefront chart an
 | `proxy.zipkinPort` | Port for Zipkin format distribued tracing data (usually 9411)| `nil` |
 | `proxy.traceSamplingRate` | Distributed tracing data sampling rate (0 to 1) | `nil` |
 | `proxy.traceSamplingDuration` | When set to greater than 0, spans that exceed this duration will force trace to be sampled (ms) | `nil` |
+| `proxy.traceJaegerApplicationName` | Custom application name for traces received on Jaeger's traceJaegerListenerPorts or traceJaegerHttpListenerPorts. | `nil` |
+| `proxy.traceZipkinApplicationName` | Custom application name for traces received on Zipkin's traceZipkinListenerPorts. | `nil` |
 | `proxy.histogramPort` | Port for histogram distribution format data (usually 40000) | `nil` |
 | `proxy.histogramMinutePort` | Port to accumulate 1-minute based histograms on Wavefront data format (usually 40001) | `nil` |
 | `proxy.histogramHourPort` | Port to accumulate 1-hour based histograms on Wavefront data format (usually 40002) | `nil` |

--- a/wavefront/templates/proxy-deployment.yaml
+++ b/wavefront/templates/proxy-deployment.yaml
@@ -41,6 +41,8 @@ spec:
           {{- if .Values.proxy.zipkinPort }} --traceZipkinListenerPorts {{ .Values.proxy.zipkinPort }}{{- end -}}
           {{- if .Values.proxy.traceSamplingRate }} --traceSamplingRate {{ .Values.proxy.traceSamplingRate }}{{- end -}}
           {{- if .Values.proxy.traceSamplingDuration }} --traceSamplingDuration {{ .Values.proxy.traceSamplingDuration }}{{- end -}}
+          {{- if .Values.proxy.traceJaegerApplicationName }} --traceJaegerApplicationName {{ .Values.proxy.traceJaegerApplicationName }}{{- end -}}
+          {{- if .Values.proxy.traceZipkinApplicationName }} --traceZipkinApplicationName {{ .Values.proxy.traceZipkinApplicationName }}{{- end -}}
           {{- if .Values.proxy.histogramPort }} --histogramDistListenerPorts {{ .Values.proxy.histogramPort }}{{- end -}}
           {{- if .Values.proxy.histogramMinutePort }} --histogramMinuteListenerPorts {{ .Values.proxy.histogramMinutePort }}{{- end -}}
           {{- if .Values.proxy.histogramHourPort }} --histogramHourListenerPorts {{ .Values.proxy.histogramHourPort }}{{- end -}}

--- a/wavefront/values.yaml
+++ b/wavefront/values.yaml
@@ -234,6 +234,12 @@ proxy:
   ## spans that are greater than or equal to this value will be sampled.
   # traceSamplingDuration: 500
 
+  ## Custom application name for traces received on Jaeger's traceJaegerListenerPorts or traceJaegerHttpListenerPorts.
+  # traceJaegerApplicationName: MyJaegerDemo
+
+  ## Custom application name for traces received on Zipkin's traceZipkinListenerPorts.
+  # traceZipkinApplicationName: MyZipkinDemo
+
   ## The port number the proxy will listen on for histogram distributions in Wavefront Distribution format.
   ## This is usually 40000
   # histogramPort: 40000


### PR DESCRIPTION
Currently all traces using this helm chart will appears as "Zipkin" in wavefront.
This pull request is to request to unlock this feature to allow us to modify the application name