### PR TITLE
Enables optional collector config file as a secret

### DIFF
--- a/wavefront/Chart.yaml
+++ b/wavefront/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: wavefront
 description: Wavefront Collector for Kubernetes
 appVersion: 1.2.5
-version: 1.3.2
+version: 1.3.3
 keywords:
 - metric
 - monitoring

--- a/wavefront/Chart.yaml
+++ b/wavefront/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: wavefront
 description: Wavefront Collector for Kubernetes
-appVersion: 1.2.4
-version: 1.3.1
+appVersion: 1.2.5
+version: 1.3.2
 keywords:
 - metric
 - monitoring

--- a/wavefront/README.md
+++ b/wavefront/README.md
@@ -100,6 +100,7 @@ The following tables lists the configurable parameters of the Wavefront chart an
 | `serviceAccount.name` | Name of Wavefront service account | `nil` |
 | `kubeStateMetrics.enabled` | Setup and enable Kube State Metrics for collection | `false` |
 | `projectPacific.enabled` | Enable and create role binding for Tanzu kubernetes cluster | `false` |
+| `tkgi.psp.enabled` | Enable and create role binding for Tanzu Kubernetes Grid Integrated Edition | `false` |
 
 
 ## Upgrading

--- a/wavefront/README.md
+++ b/wavefront/README.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of the Wavefront chart an
 | `collector.image.tag` | Wavefront collector image tag | `{TAG_NAME}` |
 | `colletor.image.pullPolicy` | Wavefront collector image pull policy | `IfNotPresent` |
 | `collector.useDaemonset` | Use Wavefront collector in Daemonset mode | `true` |
+| `collector.useSecret` | Keep Wavefront collector configuration in Secret | `true` |
 | `collector.maxProx` | Max number of CPU cores that can be used (< 1 for default) | `0` |
 | `collector.logLevel` | Min logging level (info, debug, trace) | `info` |
 | `collector.interval` | Default metrics collection interval | `60s` |

--- a/wavefront/templates/_config.tpl
+++ b/wavefront/templates/_config.tpl
@@ -1,0 +1,164 @@
+{{- define "config.data" -}}
+clusterName: {{ .Values.clusterName }}
+enableDiscovery: {{ .Values.collector.discovery.enabled }}
+enableEvents: {{ .Values.collector.events.enabled }}
+defaultCollectionInterval: {{ .Values.collector.interval | default "60s" }}
+flushInterval: {{ .Values.collector.flushInterval | default "10s" }}
+sinkExportDataTimeout: {{ .Values.collector.sinkDelay | default "20s" }}
+
+sinks:
+{{- if .Values.collector.useProxy }}
+{{- if .Values.collector.proxyAddress }}
+- proxyAddress: {{ .Values.collector.proxyAddress }}
+{{- else }}
+- proxyAddress: {{ template "wavefront.proxy.fullname" . }}:{{ .Values.proxy.port }}
+{{- end }}
+{{- else }}
+- server: {{ .Values.wavefront.url }}
+  token: {{ .Values.wavefront.token }}
+{{- end }}
+{{- if .Values.collector.tags }}
+  tags:
+{{ tpl (toYaml .Values.collector.tags) . | indent 8 }}
+{{- end }}
+{{- if .Values.collector.filters }}
+  filters:
+{{ tpl (toYaml .Values.collector.filters) . | indent 8 }}
+{{- end }}
+
+sources:
+  kubernetes_source:
+    {{- if .Values.collector.useReadOnlyPort }}
+    url:
+    kubeletPort: 10255
+    kubeletHttps: false
+    {{- else }}
+    url: https://kubernetes.default.svc
+    kubeletPort: 10250
+    kubeletHttps: true
+    {{- end }}
+    {{- if .Values.serviceAccount.create }}
+    useServiceAccount: true
+    {{- else }}
+    useServiceAccount: false
+    {{- end }}
+    insecure: true
+    {{- if .Values.collector.usePKSPrefix }}
+    prefix: pks.kubernetes.
+    {{- else }}
+    prefix: kubernetes.
+    {{- end }}
+    filters:
+      metricBlacklist:
+      - 'kubernetes.sys_container.*'
+      - 'kubernetes.node.ephemeral_storage.*'
+
+  internal_stats_source:
+    {{- if .Values.collector.usePKSPrefix }}
+    prefix: pks.kubernetes.
+    {{- else }}
+    prefix: kubernetes.
+    {{- end }}
+
+  {{- if .Values.collector.kubernetesState }}
+  kubernetes_state_source:
+    {{- if .Values.collector.usePKSPrefix }}
+    prefix: pks.kubernetes.
+    {{- else }}
+    prefix: kubernetes.
+    {{- end }}
+  {{- end }}
+
+  telegraf_sources:
+  - plugins: []
+
+  {{- if .Values.collector.apiServerMetrics }}
+  # Kubernetes API Server
+  prometheus_sources:
+  - url: https://kubernetes.default.svc.cluster.local:443/metrics
+    httpConfig:
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    prefix: kube.apiserver.
+    filters:
+      metricWhitelist:
+      - 'kube.apiserver.apiserver.*'
+      - 'kube.apiserver.etcd.*'
+      - 'kube.apiserver.process.*'
+  {{- end }}
+
+{{- if .Values.collector.events.enabled }}
+events:
+  {{- if .Values.collector.events.filters }}
+  filters:
+{{ tpl (toYaml .Values.collector.events.filters) . | indent 8 }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.collector.discovery.enabled }}
+
+discovery:
+  {{- if .Values.collector.discovery.annotationPrefix }}
+  annotation_prefix: {{ .Values.collector.discovery.annotationPrefix | quote }}
+  {{- end }}
+  {{- if .Values.collector.discovery.enableRuntimeConfigs }}
+  enable_runtime_plugins: {{ .Values.collector.discovery.enableRuntimeConfigs }}
+  {{- end }}
+
+  plugins:
+
+  # auto-discover kube DNS
+  - name: kube-dns-discovery
+    type: prometheus
+    selectors:
+      images:
+      - '*kube-dns/sidecar*'
+      labels:
+        k8s-app:
+        - kube-dns
+    port: 10054
+    path: /metrics
+    scheme: http
+    prefix: kube.dns.
+    filters:
+      metricWhitelist:
+      - 'kube.dns.http.request.duration.microseconds'
+      - 'kube.dns.http.request.size.bytes'
+      - 'kube.dns.http.requests.total.counter'
+      - 'kube.dns.http.response.size.bytes'
+      - 'kube.dns.kubedns.dnsmasq.*'
+      - 'kube.dns.process.*'
+
+  # auto-discover coredns
+  - name: coredns-discovery
+    type: prometheus
+    selectors:
+      images:
+      - '*coredns:*'
+      labels:
+        k8s-app:
+        - kube-dns
+    port: 9153
+    path: /metrics
+    scheme: http
+    prefix: kube.coredns.
+    filters:
+      metricWhitelist:
+      - 'kube.coredns.coredns.cache.*'
+      - 'kube.coredns.coredns.dns.request.count.total.counter'
+      - 'kube.coredns.coredns.dns.request.duration.seconds'
+      - 'kube.coredns.coredns.dns.request.size.bytes'
+      - 'kube.coredns.coredns.dns.request.type.count.total.counter'
+      - 'kube.coredns.coredns.dns.response.rcode.count.total.counter'
+      - 'kube.coredns.coredns.dns.response.size.bytes'
+      - 'kube.coredns.process.*'
+
+{{- if .Values.collector.discovery.config }}
+
+# user supplied discovery config
+{{ tpl (toYaml .Values.collector.discovery.config) . | indent 2 }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/wavefront/templates/collector-cluster-role.yaml
+++ b/wavefront/templates/collector-cluster-role.yaml
@@ -71,4 +71,14 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs:
   - get
+{{- if .Values.tkgi.psp.enabled }}
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - pks-privileged
+{{- end }}
 {{- end }}

--- a/wavefront/templates/collector-config.yaml
+++ b/wavefront/templates/collector-config.yaml
@@ -66,11 +66,19 @@ data:
           - 'kubernetes.node.ephemeral_storage.*'
 
       internal_stats_source:
+        {{- if .Values.collector.usePKSPrefix }}
+        prefix: pks.kubernetes.
+        {{- else }}
         prefix: kubernetes.
+        {{- end }}
 
       {{- if .Values.collector.kubernetesState }}
       kubernetes_state_source:
+        {{- if .Values.collector.usePKSPrefix }}
+        prefix: pks.kubernetes.
+        {{- else }}
         prefix: kubernetes.
+        {{- end }}
       {{- end }}
 
       telegraf_sources:

--- a/wavefront/templates/collector-config.yaml
+++ b/wavefront/templates/collector-config.yaml
@@ -1,6 +1,10 @@
-{{- if .Values.collector.enabled }}
+{{- if .Values.collector.enabled -}}
 apiVersion: v1
+{{ if .Values.collector.useSecret -}}
+kind: Secret
+{{- else -}}
 kind: ConfigMap
+{{- end }}
 metadata:
   labels:
     app.kubernetes.io/name : {{ template "wavefront.fullname" . }}
@@ -11,167 +15,9 @@ metadata:
   name: {{ template "wavefront.collector.fullname" . }}-config
 data:
   config.yaml: |
-    clusterName: {{ .Values.clusterName }}
-    enableDiscovery: {{ .Values.collector.discovery.enabled }}
-    enableEvents: {{ .Values.collector.events.enabled }}
-    defaultCollectionInterval: {{ .Values.collector.interval | default "60s" }}
-    flushInterval: {{ .Values.collector.flushInterval | default "10s" }}
-    sinkExportDataTimeout: {{ .Values.collector.sinkDelay | default "20s" }}
-
-    sinks:
-    {{- if .Values.collector.useProxy }}
-    {{- if .Values.collector.proxyAddress }}
-    - proxyAddress: {{ .Values.collector.proxyAddress }}
-    {{- else }}
-    - proxyAddress: {{ template "wavefront.proxy.fullname" . }}:{{ .Values.proxy.port }}
-    {{- end }}
-    {{- else }}
-    - server: {{ .Values.wavefront.url }}
-      token: {{ .Values.wavefront.token }}
-    {{- end }}
-    {{- if .Values.collector.tags }}
-      tags:
-{{ tpl (toYaml .Values.collector.tags) . | indent 8 }}
-    {{- end }}
-    {{- if .Values.collector.filters }}
-      filters:
-{{ tpl (toYaml .Values.collector.filters) . | indent 8 }}
-    {{- end }}
-
-    sources:
-      kubernetes_source:
-        {{- if .Values.collector.useReadOnlyPort }}
-        url:
-        kubeletPort: 10255
-        kubeletHttps: false
-        {{- else }}
-        url: https://kubernetes.default.svc
-        kubeletPort: 10250
-        kubeletHttps: true
-        {{- end }}
-        {{- if .Values.serviceAccount.create }}
-        useServiceAccount: true
-        {{- else }}
-        useServiceAccount: false
-        {{- end }}
-        insecure: true
-        {{- if .Values.collector.usePKSPrefix }}
-        prefix: pks.kubernetes.
-        {{- else }}
-        prefix: kubernetes.
-        {{- end }}
-        filters:
-          metricBlacklist:
-          - 'kubernetes.sys_container.*'
-          - 'kubernetes.node.ephemeral_storage.*'
-
-      internal_stats_source:
-        {{- if .Values.collector.usePKSPrefix }}
-        prefix: pks.kubernetes.
-        {{- else }}
-        prefix: kubernetes.
-        {{- end }}
-
-      {{- if .Values.collector.kubernetesState }}
-      kubernetes_state_source:
-        {{- if .Values.collector.usePKSPrefix }}
-        prefix: pks.kubernetes.
-        {{- else }}
-        prefix: kubernetes.
-        {{- end }}
-      {{- end }}
-
-      telegraf_sources:
-      - plugins: []
-
-      {{- if .Values.collector.apiServerMetrics }}
-      # Kubernetes API Server
-      prometheus_sources:
-      - url: https://kubernetes.default.svc.cluster.local:443/metrics
-        httpConfig:
-          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-          tls_config:
-            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            insecure_skip_verify: true
-        prefix: kube.apiserver.
-        filters:
-          metricWhitelist:
-          - 'kube.apiserver.apiserver.*'
-          - 'kube.apiserver.etcd.*'
-          - 'kube.apiserver.process.*'
-      {{- end }}
-
-    {{- if .Values.collector.events.enabled }}
-    events:
-      {{- if .Values.collector.events.filters }}
-      filters:
-{{ tpl (toYaml .Values.collector.events.filters) . | indent 8 }}
-      {{- end }}
-    {{- end }}
-
-    {{- if .Values.collector.discovery.enabled }}
-
-    discovery:
-      {{- if .Values.collector.discovery.annotationPrefix }}
-      annotation_prefix: {{ .Values.collector.discovery.annotationPrefix | quote }}
-      {{- end }}
-      {{- if .Values.collector.discovery.enableRuntimeConfigs }}
-      enable_runtime_plugins: {{ .Values.collector.discovery.enableRuntimeConfigs }}
-      {{- end }}
-
-      plugins:
-
-      # auto-discover kube DNS
-      - name: kube-dns-discovery
-        type: prometheus
-        selectors:
-          images:
-          - '*kube-dns/sidecar*'
-          labels:
-            k8s-app:
-            - kube-dns
-        port: 10054
-        path: /metrics
-        scheme: http
-        prefix: kube.dns.
-        filters:
-          metricWhitelist:
-          - 'kube.dns.http.request.duration.microseconds'
-          - 'kube.dns.http.request.size.bytes'
-          - 'kube.dns.http.requests.total.counter'
-          - 'kube.dns.http.response.size.bytes'
-          - 'kube.dns.kubedns.dnsmasq.*'
-          - 'kube.dns.process.*'
-
-      # auto-discover coredns
-      - name: coredns-discovery
-        type: prometheus
-        selectors:
-          images:
-          - '*coredns:*'
-          labels:
-            k8s-app:
-            - kube-dns
-        port: 9153
-        path: /metrics
-        scheme: http
-        prefix: kube.coredns.
-        filters:
-          metricWhitelist:
-          - 'kube.coredns.coredns.cache.*'
-          - 'kube.coredns.coredns.dns.request.count.total.counter'
-          - 'kube.coredns.coredns.dns.request.duration.seconds'
-          - 'kube.coredns.coredns.dns.request.size.bytes'
-          - 'kube.coredns.coredns.dns.request.type.count.total.counter'
-          - 'kube.coredns.coredns.dns.response.rcode.count.total.counter'
-          - 'kube.coredns.coredns.dns.response.size.bytes'
-          - 'kube.coredns.process.*'
-
-    {{- if .Values.collector.discovery.config }}
-
-    # user supplied discovery config
-{{ tpl (toYaml .Values.collector.discovery.config) . | indent 6 }}
-    {{- end }}
-    {{- end }}
-
+{{ if .Values.collector.useSecret -}}
+{{ include "config.data" . | b64enc | indent 4 -}}
+{{- else -}}
+{{ include "config.data" . | indent 4 }}
 {{- end }}
+{{ end }}

--- a/wavefront/templates/collector-daemonset.yaml
+++ b/wavefront/templates/collector-daemonset.yaml
@@ -27,8 +27,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
-{{ if .Values.collector.tolerations }} 
-{{- toYaml .Values.collector.tolerations | indent 6 }}  
+{{ if .Values.collector.tolerations }}
+{{- toYaml .Values.collector.tolerations | indent 6 }}
 {{ end }}
       serviceAccountName: {{ template "wavefront.collector.serviceAccountName" . }}
       containers:
@@ -57,7 +57,7 @@ spec:
           valueFrom:
             fieldRef:
               apiVersion: v1
-              fieldPath: metadata.namespace        
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 8088
           protocol: TCP
@@ -66,18 +66,24 @@ spec:
         volumeMounts:
         - name: procfs
           mountPath: /host/proc
-          readOnly: true          
+          readOnly: true
         - name: config
           mountPath: /etc/collector/
           readOnly: true
     {{- if .Values.collector.priorityClassName }}
       priorityClassName: {{ .Values.collector.priorityClassName }}
-    {{- end }}     
+    {{- end }}
       volumes:
       - name: procfs
         hostPath:
           path: /proc
       - name: config
+{{- if .Values.collector.useSecret }}
+        secret:
+          secretName: {{ template "wavefront.collector.fullname" . }}-config
+{{- else }}
         configMap:
           name: {{ template "wavefront.collector.fullname" . }}-config
+{{- end }}
+
 {{- end }}

--- a/wavefront/templates/collector-deployment.yaml
+++ b/wavefront/templates/collector-deployment.yaml
@@ -41,7 +41,7 @@ spec:
 {{ toYaml .Values.collector.resources | indent 10 }}
     {{- if .Values.collector.priorityClassName }}
       priorityClassName: {{ .Values.collector.priorityClassName }}
-    {{- end }}   
+    {{- end }}
     {{- if .Values.collector.tolerations }}
       tolerations:
 {{ toYaml .Values.collector.tolerations | indent 6 }}
@@ -49,14 +49,20 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/collector/
-          readOnly: true        
+          readOnly: true
         - name: ssl-certs
           mountPath: /etc/ssl/certs
           readOnly: true
       volumes:
       - name: config
+{{ if .Values.collector.useSecret -}}
+        secret:
+          secretName: {{ template "wavefront.collector.fullname" . }}-config
+{{- else }}
         configMap:
           name: {{ template "wavefront.collector.fullname" . }}-config
+{{- end }}
+
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs

--- a/wavefront/templates/tkgi-rolebinding.yaml
+++ b/wavefront/templates/tkgi-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.tkgi.psp.enabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rolebinding-default-restricted-sa-ns_wavefront
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: psp:restricted
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:serviceaccounts
+{{ end }}

--- a/wavefront/values.yaml
+++ b/wavefront/values.yaml
@@ -20,7 +20,7 @@ collector:
   enabled: true
   image:
     repository: wavefronthq/wavefront-kubernetes-collector
-    tag: 1.2.5
+    tag: 1.2.6
     pullPolicy: IfNotPresent
 
   ## If set to true, DaemonSet will be used for the collector.

--- a/wavefront/values.yaml
+++ b/wavefront/values.yaml
@@ -28,6 +28,11 @@ collector:
   ## Setting this to true is strongly recommended
   useDaemonset: true
 
+  ## If set to true, Secret will be used for the collector configuration file.
+  ## If set to false, ConfigMap will be used for the collector configuration file.
+  ## Setting this to true is strongly recommended
+  useSecret: true
+
   ## If installing into a TKGi/PKS environment, set this to true
   # usePKSPrefix: false
 

--- a/wavefront/values.yaml
+++ b/wavefront/values.yaml
@@ -20,7 +20,7 @@ collector:
   enabled: true
   image:
     repository: wavefronthq/wavefront-kubernetes-collector
-    tag: 1.2.4
+    tag: 1.2.5
     pullPolicy: IfNotPresent
 
   ## If set to true, DaemonSet will be used for the collector.

--- a/wavefront/values.yaml
+++ b/wavefront/values.yaml
@@ -318,3 +318,9 @@ kubeStateMetrics:
 ## If enabled, a role binding to handle pod security policy will be installed within the Kubernetes cluster.
 projectPacific:
   enabled: false
+
+## Properties for TKGI environments
+tkgi:
+  psp:
+    ## If enabled, a role binding to handle pod security policy will be installed within the TKGI cluster.
+    enabled: false


### PR DESCRIPTION
Update to allow deployment of the wavefront configuration file as a Secret instead of as a ConfigMap.
When combined with [kubernetes-external-secrets](https://github.com/external-secrets/kubernetes-external-secrets), this offers a more secure method to handle credentials in user collector.discovery

Credentials should not be included in the chart's values.yaml files or checked into git.
Injection of credentials from helm and helmfile CLI is possible via the --set and --state-values-set flags.

As an example, to add rabbitmq to the service discovery configuration:
- add the rabbitmq configuration to values.yaml with the credential portion 
included as template variables.
```
collector:
  discovery:
    config:
      - name: rabbitmq
        type: telegraf/rabbitmq
        selectors:
          images:
          - 'rabbitmq*'
        port: 15672
        conf: |
          url = "http://${host}:${port}"
          username = "{{ .Values.collector.discovery.rabbitmq.user }}"
          password = "{{ .Values.collector.discovery.rabbitmq.password }}"
```
then include the desired credentials from CLI

**Helm: include credential**
```
helm install --namespace wavefront -f values.yaml wavefront . --set collector.discovery.rabbitmq.user=thetick,collector.discovery.rabbitmq.password=MysteriesAbound
```

**Helmfile: include credential**
```
helmfile -e environment_name apply \
    --state-values-set collector.discovery.rabbitmq.user='thetick' \
    --state-values-set collector.discovery.rabbitmq.password='MysteriesAbound'
```

To verify the generated config file content before deployment, use helm template to generate the output
Example:
```

helm template -f values.yaml --debug . --set collector.discovery.rabbitmq.user=thetick,collector.discovery.rabbitmq.password=MysteriesAbound
```
find the secret section and copy the base64 encoded secret data after
```
...
---
# Source: wavefront/templates/collector-config-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  labels:
    app.kubernetes.io/name : RELEASE-NAME-wavefront
    helm.sh/chart: wavefront-1.3.1
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io.instance: "RELEASE-NAME"
    app.kubernetes.io/component: collector
  name: RELEASE-NAME-wavefront-collector-config
data:
  config.yaml: |
    Y2x1c3Rlck5hbWU6IEtVQkVSTkVURVNfQ0xVU1RFUl9OQU1FCmVuYWJsZURpc2NvdmVyeTogdHJ1ZQplbmFibGVFdmVudHM6IGZhbHNlCmRlZmF1bHRDb2xsZWN0aW9uSW50ZXJ2YWw6IDYwcwpmbHVzaEludGVydmFsOiAxMHMKc2lua0V4cG9ydERhdGFUaW1lb3V0OiAyMHMKCnNpbmtzOgotIHByb3h5QWRkcmVzczogUkVMRUFTRS1OQU1FLXdhdmVmcm9udC1wcm94eToyODc4CiAgZmlsdGVyczoKICAgICAgICB0YWdFeGNsdWRlOgogICAgICAgIC0gbGFiZWw/Y29udHJvbGxlcj9yZXZpc2lvbioKICAgICAgICAtIGxhYmVsP3BvZD90ZW1wbGF0ZSoKICAgICAgICAtIGFubm90YXRpb25fa3ViZWN0bF9rdWJlcm5ldGVzX2lvX2xhc3RfYXBwbGllZF9jb25maWd1cmF0aW9uCgpzb3VyY2VzOgogIGt1YmVybmV0ZXNfc291cmNlOgogICAgdXJsOiBodHRwczovL2t1YmVybmV0ZXMuZGVmYXVsdC5zdmMKICAgIGt1YmVsZXRQb3J0OiAxMDI1MAogICAga3ViZWxldEh0dHBzOiB0cnVlCiAgICB1c2VTZXJ2aWNlQWNjb3VudDogdHJ1ZQogICAgaW5zZWN1cmU6IHRydWUKICAgIHByZWZpeDoga3ViZXJuZXRlcy4KICAgIGZpbHRlcnM6CiAgICAgIG1ldHJpY0JsYWNrbGlzdDoKICAgICAgLSAna3ViZXJuZXRlcy5zeXNfY29udGFpbmVyLionCiAgICAgIC0gJ2t1YmVybmV0ZXMubm9kZS5lcGhlbWVyYWxfc3RvcmFnZS4qJwoKICBpbnRlcm5hbF9zdGF0c19zb3VyY2U6CiAgICBwcmVmaXg6IGt1YmVybmV0ZXMuCiAga3ViZXJuZXRlc19zdGF0ZV9zb3VyY2U6CiAgICBwcmVmaXg6IGt1YmVybmV0ZXMuCgogIHRlbGVncmFmX3NvdXJjZXM6CiAgLSBwbHVnaW5zOiBbXQoKZGlzY292ZXJ5OgogIGVuYWJsZV9ydW50aW1lX3BsdWdpbnM6IHRydWUKCiAgcGx1Z2luczoKCiAgIyBhdXRvLWRpc2NvdmVyIGt1YmUgRE5TCiAgLSBuYW1lOiBrdWJlLWRucy1kaXNjb3ZlcnkKICAgIHR5cGU6IHByb21ldGhldXMKICAgIHNlbGVjdG9yczoKICAgICAgaW1hZ2VzOgogICAgICAtICcqa3ViZS1kbnMvc2lkZWNhcionCiAgICAgIGxhYmVsczoKICAgICAgICBrOHMtYXBwOgogICAgICAgIC0ga3ViZS1kbnMKICAgIHBvcnQ6IDEwMDU0CiAgICBwYXRoOiAvbWV0cmljcwogICAgc2NoZW1lOiBodHRwCiAgICBwcmVmaXg6IGt1YmUuZG5zLgogICAgZmlsdGVyczoKICAgICAgbWV0cmljV2hpdGVsaXN0OgogICAgICAtICdrdWJlLmRucy5odHRwLnJlcXVlc3QuZHVyYXRpb24ubWljcm9zZWNvbmRzJwogICAgICAtICdrdWJlLmRucy5odHRwLnJlcXVlc3Quc2l6ZS5ieXRlcycKICAgICAgLSAna3ViZS5kbnMuaHR0cC5yZXF1ZXN0cy50b3RhbC5jb3VudGVyJwogICAgICAtICdrdWJlLmRucy5odHRwLnJlc3BvbnNlLnNpemUuYnl0ZXMnCiAgICAgIC0gJ2t1YmUuZG5zLmt1YmVkbnMuZG5zbWFzcS4qJwogICAgICAtICdrdWJlLmRucy5wcm9jZXNzLionCgogICMgYXV0by1kaXNjb3ZlciBjb3JlZG5zCiAgLSBuYW1lOiBjb3JlZG5zLWRpc2NvdmVyeQogICAgdHlwZTogcHJvbWV0aGV1cwogICAgc2VsZWN0b3JzOgogICAgICBpbWFnZXM6CiAgICAgIC0gJypjb3JlZG5zOionCiAgICAgIGxhYmVsczoKICAgICAgICBrOHMtYXBwOgogICAgICAgIC0ga3ViZS1kbnMKICAgIHBvcnQ6IDkxNTMKICAgIHBhdGg6IC9tZXRyaWNzCiAgICBzY2hlbWU6IGh0dHAKICAgIHByZWZpeDoga3ViZS5jb3JlZG5zLgogICAgZmlsdGVyczoKICAgICAgbWV0cmljV2hpdGVsaXN0OgogICAgICAtICdrdWJlLmNvcmVkbnMuY29yZWRucy5jYWNoZS4qJwogICAgICAtICdrdWJlLmNvcmVkbnMuY29yZWRucy5kbnMucmVxdWVzdC5jb3VudC50b3RhbC5jb3VudGVyJwogICAgICAtICdrdWJlLmNvcmVkbnMuY29yZWRucy5kbnMucmVxdWVzdC5kdXJhdGlvbi5zZWNvbmRzJwogICAgICAtICdrdWJlLmNvcmVkbnMuY29yZWRucy5kbnMucmVxdWVzdC5zaXplLmJ5dGVzJwogICAgICAtICdrdWJlLmNvcmVkbnMuY29yZWRucy5kbnMucmVxdWVzdC50eXBlLmNvdW50LnRvdGFsLmNvdW50ZXInCiAgICAgIC0gJ2t1YmUuY29yZWRucy5jb3JlZG5zLmRucy5yZXNwb25zZS5yY29kZS5jb3VudC50b3RhbC5jb3VudGVyJwogICAgICAtICdrdWJlLmNvcmVkbnMuY29yZWRucy5kbnMucmVzcG9uc2Uuc2l6ZS5ieXRlcycKICAgICAgLSAna3ViZS5jb3JlZG5zLnByb2Nlc3MuKicKCiMgdXNlciBzdXBwbGllZCBkaXNjb3ZlcnkgY29uZmlnCiAgLSBjb25mOiB8CiAgICAgIHVybCA9ICJodHRwOi8vJHtob3N0fToke3BvcnR9IgogICAgICB1c2VybmFtZSA9ICJ0aGV0aWNrIgogICAgICBwYXNzd29yZCA9ICJNeXN0ZXJpZXNBYm91bmQiCiAgICBuYW1lOiByYWJiaXRtcQogICAgcG9ydDogMTU2NzIKICAgIHNlbGVjdG9yczoKICAgICAgaW1hZ2VzOgogICAgICAtIHJhYmJpdG1xKgogICAgdHlwZTogdGVsZWdyYWYvcmFiYml0bXEK
---
...

```
and decode the base64 encoded secret data.
```
pbpaste | base64 --decode

clusterName: KUBERNETES_CLUSTER_NAME
enableDiscovery: true
enableEvents: false
defaultCollectionInterval: 60s
flushInterval: 10s
sinkExportDataTimeout: 20s

sinks:
- proxyAddress: RELEASE-NAME-wavefront-proxy:2878
  filters:
        tagExclude:
        - label?controller?revision*
        - label?pod?template*
        - annotation_kubectl_kubernetes_io_last_applied_configuration

sources:
  kubernetes_source:
    url: https://kubernetes.default.svc
    kubeletPort: 10250
    kubeletHttps: true
    useServiceAccount: true
    insecure: true
    prefix: kubernetes.
    filters:
      metricBlacklist:
      - 'kubernetes.sys_container.*'
      - 'kubernetes.node.ephemeral_storage.*'

  internal_stats_source:
    prefix: kubernetes.
  kubernetes_state_source:
    prefix: kubernetes.

  telegraf_sources:
  - plugins: []

discovery:
  enable_runtime_plugins: true

  plugins:

  # auto-discover kube DNS
  - name: kube-dns-discovery
    type: prometheus
    selectors:
      images:
      - '*kube-dns/sidecar*'
      labels:
        k8s-app:
        - kube-dns
    port: 10054
    path: /metrics
    scheme: http
    prefix: kube.dns.
    filters:
      metricWhitelist:
      - 'kube.dns.http.request.duration.microseconds'
      - 'kube.dns.http.request.size.bytes'
      - 'kube.dns.http.requests.total.counter'
      - 'kube.dns.http.response.size.bytes'
      - 'kube.dns.kubedns.dnsmasq.*'
      - 'kube.dns.process.*'

  # auto-discover coredns
  - name: coredns-discovery
    type: prometheus
    selectors:
      images:
      - '*coredns:*'
      labels:
        k8s-app:
        - kube-dns
    port: 9153
    path: /metrics
    scheme: http
    prefix: kube.coredns.
    filters:
      metricWhitelist:
      - 'kube.coredns.coredns.cache.*'
      - 'kube.coredns.coredns.dns.request.count.total.counter'
      - 'kube.coredns.coredns.dns.request.duration.seconds'
      - 'kube.coredns.coredns.dns.request.size.bytes'
      - 'kube.coredns.coredns.dns.request.type.count.total.counter'
      - 'kube.coredns.coredns.dns.response.rcode.count.total.counter'
      - 'kube.coredns.coredns.dns.response.size.bytes'
      - 'kube.coredns.process.*'

# user supplied discovery config
  - conf: |
      url = "http://${host}:${port}"
      username = "thetick"
      password = "MysteriesAbound"
    name: rabbitmq
    port: 15672
    selectors:
      images:
      - rabbitmq*
    type: telegraf/rabbitmq
```
