### PR TITLE
implement exposing the updateStrategy in the values file

### DIFF
--- a/wavefront/README.md
+++ b/wavefront/README.md
@@ -54,6 +54,7 @@ The following tables lists the configurable parameters of the Wavefront chart an
 | `collector.image.repository` | Wavefront collector image registry and name | `wavefronthq/wavefront-kubernetes-collector` |
 | `collector.image.tag` | Wavefront collector image tag | `{TAG_NAME}` |
 | `colletor.image.pullPolicy` | Wavefront collector image pull policy | `IfNotPresent` |
+| `colletor.image.updateStrategy` | Wavefront collector updateStrategy | `nil` |
 | `collector.useDaemonset` | Use Wavefront collector in Daemonset mode | `true` |
 | `collector.maxProx` | Max number of CPU cores that can be used (< 1 for default) | `0` |
 | `collector.logLevel` | Min logging level (info, debug, trace) | `info` |

--- a/wavefront/templates/collector-daemonset.yaml
+++ b/wavefront/templates/collector-daemonset.yaml
@@ -14,6 +14,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name : {{ template "wavefront.fullname" .}}
       app.kubernetes.io/component: collector
+{{ if .Values.collector.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.collector.updateStrategy | indent 4 }}
+{{ end }}
   template:
     metadata:
       labels:
@@ -27,8 +31,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
-{{ if .Values.collector.tolerations }} 
-{{- toYaml .Values.collector.tolerations | indent 6 }}  
+{{ if .Values.collector.tolerations }}
+{{- toYaml .Values.collector.tolerations | indent 6 }}
 {{ end }}
       serviceAccountName: {{ template "wavefront.collector.serviceAccountName" . }}
       containers:
@@ -57,7 +61,7 @@ spec:
           valueFrom:
             fieldRef:
               apiVersion: v1
-              fieldPath: metadata.namespace        
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 8088
           protocol: TCP
@@ -66,13 +70,13 @@ spec:
         volumeMounts:
         - name: procfs
           mountPath: /host/proc
-          readOnly: true          
+          readOnly: true
         - name: config
           mountPath: /etc/collector/
           readOnly: true
     {{- if .Values.collector.priorityClassName }}
       priorityClassName: {{ .Values.collector.priorityClassName }}
-    {{- end }}     
+    {{- end }}
       volumes:
       - name: procfs
         hostPath:

--- a/wavefront/templates/collector-deployment.yaml
+++ b/wavefront/templates/collector-deployment.yaml
@@ -16,6 +16,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name : {{ template "wavefront.fullname" .}}
       app.kubernetes.io/component: collector
+{{ if .Values.collector.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.collector.updateStrategy | indent 4 }}
+{{ end }}
   template:
     metadata:
       labels:
@@ -41,7 +45,7 @@ spec:
 {{ toYaml .Values.collector.resources | indent 10 }}
     {{- if .Values.collector.priorityClassName }}
       priorityClassName: {{ .Values.collector.priorityClassName }}
-    {{- end }}   
+    {{- end }}
     {{- if .Values.collector.tolerations }}
       tolerations:
 {{ toYaml .Values.collector.tolerations | indent 6 }}
@@ -49,7 +53,7 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/collector/
-          readOnly: true        
+          readOnly: true
         - name: ssl-certs
           mountPath: /etc/ssl/certs
           readOnly: true

--- a/wavefront/values.yaml
+++ b/wavefront/values.yaml
@@ -23,6 +23,13 @@ collector:
     tag: 1.2.6
     pullPolicy: IfNotPresent
 
+  ## Set the updateStrategy for the collector deployment or daemonset
+  ## if no updateStrategy is set, it will use the defaults.
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
   ## If set to true, DaemonSet will be used for the collector.
   ## If set to false, Deployment will be used for the collector.
   ## Setting this to true is strongly recommended

--- a/wavefront/values.yaml
+++ b/wavefront/values.yaml
@@ -25,10 +25,10 @@ collector:
 
   ## Set the updateStrategy for the collector deployment or daemonset
   ## if no updateStrategy is set, it will use the defaults.
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+  # updateStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 1
 
   ## If set to true, DaemonSet will be used for the collector.
   ## If set to false, Deployment will be used for the collector.


### PR DESCRIPTION
I would like to expose the `updateStrategy` of the collector to the values file so there is a little more control with the deployment to large node clusters. Currently helm times out with the default `updateStrategy` unless the timeout is set to 30min +.

I exposed the whole block because I would like to control the `maxUnavailable` and other properties. I know some helm charts have only exposed the `updateStrategy.type` field which imo doesn't afford enough control to the end user.

kubeval output for the deployment:
```
➜   helm template wavefront . | kubeval -
PASS - wavefront/templates/collector-service-account.yaml contains a valid ServiceAccount (wavefront-collector)
PASS - wavefront/templates/api-token-secret.yaml contains a valid Secret (wavefront)
PASS - wavefront/templates/collector-config.yaml contains a valid ConfigMap (wavefront-collector-config)
PASS - wavefront/templates/collector-cluster-role.yaml contains a valid ClusterRole (wavefront-collector)
PASS - wavefront/templates/collector-rbac.yaml contains a valid ClusterRoleBinding (wavefront-collector)
PASS - wavefront/templates/proxy-service.yaml contains a valid Service (wavefront-proxy)
PASS - wavefront/templates/collector-deployment.yaml contains a valid Deployment (wavefront-collector)
PASS - wavefront/templates/proxy-deployment.yaml contains a valid Deployment (wavefront-proxy)
```

kubeval output for the daemonset:

```
➜   helm template wavefront . | kubeval -
PASS - wavefront/templates/collector-service-account.yaml contains a valid ServiceAccount (wavefront-collector)
PASS - wavefront/templates/api-token-secret.yaml contains a valid Secret (wavefront)
PASS - wavefront/templates/collector-config.yaml contains a valid ConfigMap (wavefront-collector-config)
PASS - wavefront/templates/collector-cluster-role.yaml contains a valid ClusterRole (wavefront-collector)
PASS - wavefront/templates/collector-rbac.yaml contains a valid ClusterRoleBinding (wavefront-collector)
PASS - wavefront/templates/proxy-service.yaml contains a valid Service (wavefront-proxy)
PASS - wavefront/templates/collector-daemonset.yaml contains a valid DaemonSet (wavefront-collector)
PASS - wavefront/templates/proxy-deployment.yaml contains a valid Deployment (wavefront-proxy)
```