### PR TITLE
wavefront proxy: Add javaArgs to workaround log4j vulnerability

### DIFF
--- a/wavefront/README.md
+++ b/wavefront/README.md
@@ -81,6 +81,7 @@ The following tables lists the configurable parameters of the Wavefront chart an
 | `proxy.image.pullPolicy` | Wavefront proxy image pull policy | `IfNotPresent` |
 | `proxy.replicas` | Replicas to deploy for Wavefront proxy (usually 1) | `1` |
 | `proxy.port` | Primary port for Wavefront data format metrics | `2878` |
+| `proxy.javaArgs` | Wavefront proxy Java arguments | `-Dlog4j2.formatMsgNoLookups=true` |
 | `proxy.tracePort` | Port for distributed tracing data (usually 30000) | `nil` |
 | `proxy.jaegerPort` | Port for Jaeger format distributed tracing data (usually 30001) | `nil` |
 | `proxy.traceJaegerHttpListenerPort` | Port for Jaeger Thrift format data (usually 30080) | `nil` |

--- a/wavefront/templates/proxy-deployment.yaml
+++ b/wavefront/templates/proxy-deployment.yaml
@@ -36,6 +36,8 @@ spec:
             secretKeyRef:
               name: {{ template "wavefront.fullname" . }}
               key: api-token
+        - name: JAVA_ARGS
+          value: {{ .Values.proxy.javaArgs | quote }}
         - name: WAVEFRONT_PROXY_ARGS
           value: {{ .Values.proxy.args }}
           {{- if .Values.proxy.tracePort }} --traceListenerPorts {{ .Values.proxy.tracePort }}{{- end -}}

--- a/wavefront/values.yaml
+++ b/wavefront/values.yaml
@@ -246,6 +246,9 @@ proxy:
   ## This is usually 2878
   port: 2878
 
+  ## Additional java arguments to be set using the JAVA_ARGS env variable
+  javaArgs: '-Dlog4j2.formatMsgNoLookups=true'
+
   ## The port nubmer the proxy will listen on for tracing spans in Wavefront trace data format.
   ## This is usually 30000
   # tracePort: 30000


### PR DESCRIPTION
Resolves https://github.com/wavefrontHQ/helm/issues/135