### PR TITLE
Optimize slack notifications to be only on a build status change

### DIFF
--- a/ci.Jenkinsfile
+++ b/ci.Jenkinsfile
@@ -35,14 +35,19 @@ pipeline {
   }
 
   post {
+    // Notify only on null->failure or success->failure or failure->success
+    failure {
+      script {
+        if(currentBuild.previousBuild == null) {
+          slackSend (channel: '#tobs-k8po-team', color: '#FF0000', message: "CI TEST FAILED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
+        }
+      }
+    }
     regression {
-      slackSend (channel: '#tobs-k8po-team', color: '#FF0000', message: "TEST FAILED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
+      slackSend (channel: '#tobs-k8po-team', color: '#FF0000', message: "CI TEST FAILED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
     }
     fixed {
-      slackSend (channel: '#tobs-k8po-team', color: '#008000', message: "TEST FIXED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
-    }
-    success {
-      slackSend (channel: '#tobs-k8po-team', color: '#008000', message: "TEST SUCCESS: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
+      slackSend (channel: '#tobs-k8po-team', color: '#008000', message: "CI TEST FIXED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
     }
     always {
       cleanWs()

--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
       }
     }
   }
+
   post {
     // Notify only on null->failure or success->failure or failure->success
     failure {

--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -34,16 +34,20 @@ pipeline {
       }
     }
   }
-
   post {
+    // Notify only on null->failure or success->failure or failure->success
+    failure {
+      script {
+        if(currentBuild.previousBuild == null) {
+          slackSend (channel: '#tobs-k8po-team', color: '#FF0000', message: "RELEASE BUILD FAILED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
+        }
+      }
+    }
     regression {
-      slackSend (channel: '#tobs-k8po-team', color: '#FF0000', message: "BUILD FAILED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
+      slackSend (channel: '#tobs-k8po-team', color: '#FF0000', message: "RELEASE BUILD FAILED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
     }
     fixed {
-      slackSend (channel: '#tobs-k8po-team', color: '#008000', message: "BUILD FIXED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
-    }
-    success {
-      slackSend (channel: '#tobs-k8po-team', color: '#008000', message: "BUILD SUCCESS: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
+      slackSend (channel: '#tobs-k8po-team', color: '#008000', message: "RELEASE BUILD FIXED: <${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
     }
     always {
       cleanWs()


### PR DESCRIPTION
Refactored the Jenkins' slack notifications to reflect the below for helm:

- Notify #tobs-k8po-team only when there is a build status change ie., (null->failure) or (success->failure) or (failure->success)
- Since Helm repo's release build does not actually make a release, we don't need to send a notification to #tobs-k8s-assist, like we do in [wavefront-collector-for-kubernetes/PR #380](https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes/pull/380)