### PR TITLE
 Downgrade kubectl to v1.23.6 due to compatiblity issues

### DIFF
--- a/ci.Jenkinsfile
+++ b/ci.Jenkinsfile
@@ -35,28 +35,28 @@ pipeline {
          }
        }
      }
-//     stage("Run Tests on EKS") {
-//       environment {
-//         AWS_SHARED_CREDENTIALS_FILE = credentials("k8po-ci-aws-creds")
-//         AWS_CONFIG_FILE = credentials("k8po-ci-aws-profile")
-//         AWS_REGION = "us-west-2"
-//         AWS_PROFILE = "wavefront-dev"
-//         ECR_ENDPOINT = "095415062695.dkr.ecr.us-west-2.amazonaws.com"
-//         WAVEFRONT_TOKEN = credentials('WAVEFRONT_TOKEN_NIMBA')
-//       }
-//       steps {
-//         withEnv(["PATH+EXTRA=${PWD}/node-v16.14.0-linux-x64/bin", "PATH+GCLOUD=${HOME}/google-cloud-sdk/bin"]) {
-//           lock("integration-test-eks") {
-//             sh 'aws ecr get-login-password --region $AWS_REGION --profile $AWS_PROFILE |  docker login --username AWS --password-stdin $ECR_ENDPOINT'
-//             sh 'aws eks --region $AWS_REGION update-kubeconfig --name k8s-saas-team-dev --profile $AWS_PROFILE'
-//             script {
-//               env.PREV_CHART_VERSION = sh(returnStdout: true, script: "curl -s -X 'GET' 'https://artifacthub.io/api/v1/packages/helm/wavefront/wavefront' -H 'accept: application/json' | jq -r '.available_versions[0].version'").trim()
-//             }
-//             sh './wavefront/release/run-e2e-tests.sh -t ${WAVEFRONT_TOKEN} -p ${PREV_CHART_VERSION}'
-//           }
-//         }
-//       }
-//     }
+    stage("Run Tests on EKS") {
+      environment {
+        AWS_SHARED_CREDENTIALS_FILE = credentials("k8po-ci-aws-creds")
+        AWS_CONFIG_FILE = credentials("k8po-ci-aws-profile")
+        AWS_REGION = "us-west-2"
+        AWS_PROFILE = "wavefront-dev"
+        ECR_ENDPOINT = "095415062695.dkr.ecr.us-west-2.amazonaws.com"
+        WAVEFRONT_TOKEN = credentials('WAVEFRONT_TOKEN_NIMBA')
+      }
+      steps {
+        withEnv(["PATH+EXTRA=${PWD}/node-v16.14.0-linux-x64/bin", "PATH+GCLOUD=${HOME}/google-cloud-sdk/bin"]) {
+          lock("integration-test-eks") {
+            sh 'aws ecr get-login-password --region $AWS_REGION --profile $AWS_PROFILE |  docker login --username AWS --password-stdin $ECR_ENDPOINT'
+            sh 'aws eks --region $AWS_REGION update-kubeconfig --name k8s-saas-team-dev --profile $AWS_PROFILE'
+            script {
+              env.PREV_CHART_VERSION = sh(returnStdout: true, script: "curl -s -X 'GET' 'https://artifacthub.io/api/v1/packages/helm/wavefront/wavefront' -H 'accept: application/json' | jq -r '.available_versions[0].version'").trim()
+            }
+            sh './wavefront/release/run-e2e-tests.sh -t ${WAVEFRONT_TOKEN} -p ${PREV_CHART_VERSION}'
+          }
+        }
+      }
+    }
   }
 
   post {

--- a/wavefront/release/setup-for-integration-test.sh
+++ b/wavefront/release/setup-for-integration-test.sh
@@ -35,7 +35,8 @@ docker-credential-gcr configure-docker --registries="us.gcr.io"
 #
 # kubectl
 #
-curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+#curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+curl -LO "https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl"
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
The aws-cli produces a kubeconfig that is incompatible with v1.24.x version of kubectl. See https://github.com/aws/aws-cli/issues/6920 for more details.