### PR TITLE
Fix the wavefront proxy argument for `deltaCounterPort`

### DIFF
--- a/wavefront/templates/proxy-deployment.yaml
+++ b/wavefront/templates/proxy-deployment.yaml
@@ -51,7 +51,7 @@ spec:
           {{- if .Values.proxy.histogramMinutePort }} --histogramMinuteListenerPorts {{ .Values.proxy.histogramMinutePort }}{{- end -}}
           {{- if .Values.proxy.histogramHourPort }} --histogramHourListenerPorts {{ .Values.proxy.histogramHourPort }}{{- end -}}
           {{- if .Values.proxy.histogramDayPort }} --histogramDayListenerPorts {{ .Values.proxy.histogramDayPort }}{{- end -}}
-          {{- if .Values.proxy.deltaCounterPort }} --deltaCounterPorts {{ .Values.proxy.deltaCounterPort }}{{- end -}}
+          {{- if .Values.proxy.deltaCounterPort }} --deltaCountersAggregationListenerPorts {{ .Values.proxy.deltaCounterPort }}{{- end -}}
           {{- if .Values.proxy.preprocessor }} --preprocessorConfigFile /etc/wavefront/wavefront-proxy/preprocessor/rules.yaml{{- end -}}
           {{- if .Values.proxy.httpProxyHost }} --proxyHost {{ .Values.proxy.httpProxyHost }}{{- end -}}
           {{- if .Values.proxy.httpProxyPort }} --proxyPort {{ .Values.proxy.httpProxyPort }}{{- end -}}


### PR DESCRIPTION
The wavefront proxy use `--deltaCountersAggregationListenerPorts` instead of  `--deltaCounterPorts`, see: https://github.com/wavefrontHQ/wavefront-proxy/blob/master/proxy/src/main/java/com/wavefront/agent/ProxyConfig.java#L1211