### PR TITLE
Feat: add logic to get token from a secret

### DIFF
--- a/wavefront-hpa-adapter/README.md
+++ b/wavefront-hpa-adapter/README.md
@@ -48,8 +48,7 @@ The following tables lists the configurable parameters of the Wavefront chart an
 | --- | --- | --- |
 | `wavefront.url` | Wavefront URL for your cluster | `https://YOUR_CLUSTER.wavefront.com` |
 | `wavefront.token` | Wavefront API Token | `YOUR_API_TOKEN` |
-| `wavefront.secret.name` | Wavefront secret name API Token | `nil` |
-| `wavefront.secret.key` | Wavefront secret key API Token | `nil` |
+| `wavefront.secret.tokenFromSecret` | Name of the secret where the api token is stored | `nil` |
 | `image.repository` | Wavefront HPA adapter image registry and name | `wavefronthq/wavefront-hpa-adapter` |
 | `image.tag` | Wavefront HPA adapter image tag | `{TAG_NAME}` |
 | `image.pullPolicy` | Wavefront HPA adapter image pull policy | `IfNotPresent` |

--- a/wavefront-hpa-adapter/README.md
+++ b/wavefront-hpa-adapter/README.md
@@ -48,6 +48,8 @@ The following tables lists the configurable parameters of the Wavefront chart an
 | --- | --- | --- |
 | `wavefront.url` | Wavefront URL for your cluster | `https://YOUR_CLUSTER.wavefront.com` |
 | `wavefront.token` | Wavefront API Token | `YOUR_API_TOKEN` |
+| `wavefront.secret.name` | Wavefront secret name API Token | `nil` |
+| `wavefront.secret.key` | Wavefront secret key API Token | `nil` |
 | `image.repository` | Wavefront HPA adapter image registry and name | `wavefronthq/wavefront-hpa-adapter` |
 | `image.tag` | Wavefront HPA adapter image tag | `{TAG_NAME}` |
 | `image.pullPolicy` | Wavefront HPA adapter image pull policy | `IfNotPresent` |

--- a/wavefront-hpa-adapter/templates/NOTES.txt
+++ b/wavefront-hpa-adapter/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{- $validUrl := and (.Values.wavefront.url) (ne .Values.wavefront.url "https://YOUR_CLUSTER.wavefront.com") -}}
-{{- $validToken := and (.Values.wavefront.token) (ne .Values.wavefront.token "YOUR_API_TOKEN") -}}
+{{- $validToken := or (.Values.wavefront.token) (.Values.wavefront.tokenFromSecret) -}}
 
 {{- if or (not $validUrl) (not $validToken) }}
 

--- a/wavefront-hpa-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/wavefront-hpa-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - "/wavefront-adapter"
         - "--wavefront-url={{ required "You must configure a valid URL" .Values.wavefront.url }}"
       {{- if .Values.wavefront.tokenFromSecret }}
-        - "--wavefront-token=${WAVEFRONT_TOKEN}"
+        - "--wavefront-token=$(WAVEFRONT_TOKEN)"
       {{- else }}
         - "--wavefront-token={{ required "You must configure a valid Token" .Values.wavefront.token }}"
       {{- end }}

--- a/wavefront-hpa-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/wavefront-hpa-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -21,10 +21,22 @@ spec:
       - name: custom-metrics-apiserver
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+      {{- if .Values.wavefront.secret }}
+        env:
+        - name: WAVEFRONT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.wavefront.secret.name }}
+              key: api-token
+      {{- end }}}
         args:
         - "/wavefront-adapter"
         - "--wavefront-url={{ required "You must configure a valid URL" .Values.wavefront.url }}"
+      {{- if .Values.wavefront.token }}
         - "--wavefront-token={{ required "You must configure a valid Token" .Values.wavefront.token }}"
+      {{- else }}
+        - "--wavefront-token=${WAVEFRONT_TOKEN}"
+      {{- end }}
         - "--wavefront-metric-prefix={{ .Values.adapter.metricPrefix }}"
         - "--metrics-relist-interval={{ .Values.adapter.metricRelistInterval }}"
         - "--api-client-timeout={{ .Values.adapter.apiClientTimeout }}"

--- a/wavefront-hpa-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/wavefront-hpa-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -27,8 +27,8 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ .Values.wavefront.secret.name }}
-              key: api-token
-      {{- end }}}
+              key: {{ .Values.wavefront.secret.key }}
+      {{- end }}
         args:
         - "/wavefront-adapter"
         - "--wavefront-url={{ required "You must configure a valid URL" .Values.wavefront.url }}"

--- a/wavefront-hpa-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/wavefront-hpa-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -21,21 +21,21 @@ spec:
       - name: custom-metrics-apiserver
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-      {{- if .Values.wavefront.secret }}
+      {{- if .Values.wavefront.tokenFromSecret }}
         env:
         - name: WAVEFRONT_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.wavefront.secret.name }}
-              key: {{ .Values.wavefront.secret.key }}
+              name: {{ .Values.wavefront.tokenFromSecret }}
+              key: token
       {{- end }}
         args:
         - "/wavefront-adapter"
         - "--wavefront-url={{ required "You must configure a valid URL" .Values.wavefront.url }}"
-      {{- if .Values.wavefront.token }}
-        - "--wavefront-token={{ required "You must configure a valid Token" .Values.wavefront.token }}"
-      {{- else }}
+      {{- if .Values.wavefront.tokenFromSecret }}
         - "--wavefront-token=${WAVEFRONT_TOKEN}"
+      {{- else }}
+        - "--wavefront-token={{ required "You must configure a valid Token" .Values.wavefront.token }}"
       {{- end }}
         - "--wavefront-metric-prefix={{ .Values.adapter.metricPrefix }}"
         - "--metrics-relist-interval={{ .Values.adapter.metricRelistInterval }}"

--- a/wavefront-hpa-adapter/values.yaml
+++ b/wavefront-hpa-adapter/values.yaml
@@ -13,12 +13,7 @@ wavefront:
   token: YOUR_API_TOKEN
 
   # OPTIONAL, Allow to use a secret to pull the credentials.
-  secret:
-    # Name of the secret containing the Wavefront API token
-    name: ""
-
-    # Key in the secret containing the Wavefront API token
-    key: ""
+  tokenFromSecret: ""
 
 adapter:
   # Metrics under this prefix are exposed via the custom metrics API

--- a/wavefront-hpa-adapter/values.yaml
+++ b/wavefront-hpa-adapter/values.yaml
@@ -18,7 +18,7 @@ wavefront:
     name: ""
 
     # Key in the secret containing the Wavefront API token
-    key: "api-token"
+    key: ""
 
 adapter:
   # Metrics under this prefix are exposed via the custom metrics API

--- a/wavefront-hpa-adapter/values.yaml
+++ b/wavefront-hpa-adapter/values.yaml
@@ -8,8 +8,17 @@ image:
 wavefront:
   url: https://YOUR_CLUSTER.wavefront.com
 
-  # Wavefront API token with permissions to query for points
+# Required one of the following:
+  # OPTIONAL, Wavefront API token with permissions to query for points. If token is not provided, the adapter will look for a secret.
   token: YOUR_API_TOKEN
+
+  # OPTIONAL, Allow to use a secret to pull the credentials.
+  secret:
+    # Name of the secret containing the Wavefront API token
+    name: ""
+
+    # Key in the secret containing the Wavefront API token
+    key: "api-token"
 
 adapter:
   # Metrics under this prefix are exposed via the custom metrics API


### PR DESCRIPTION
* To have a gitops flow it is necessary not to leave the api token in raw in git. To do this we propose to use an environment variable obtained from a secret (which could be the same as the wavefront proxy)